### PR TITLE
Allow multiple provider networks

### DIFF
--- a/src/services/openstack/openstack.service.ts
+++ b/src/services/openstack/openstack.service.ts
@@ -270,11 +270,11 @@ export class OpenstackService implements CloudProvider {
                     name: group
                 }
             }),
-            networks: [
+            networks: this._network.addressProviderUUID.split(',').map((uuid) => (
                 {
-                    uuid: this._network.addressProviderUUID
+                    uuid: uuid
                 }
-            ],
+            )),
             metadata,
             user_data: Buffer.from(bootCommand).toString('base64')
         }


### PR DESCRIPTION
Add the ability to set multiple addressProviderUUID (comma separated) in new instances.
So the `VISA_WEB_PROVIDER_OPENSTACK_ADDRESS_PROVIDER_UUID` envvar become something like `providerUUID-1,providerUUID-2`