### PR TITLE
Fix build state

### DIFF
--- a/src/services/openstack/openstack.service.ts
+++ b/src/services/openstack/openstack.service.ts
@@ -114,7 +114,7 @@ export class OpenstackService implements CloudProvider {
 
         const state = (status, taskStatus): CloudInstanceState => {
             switch (status) {
-                case "BUILDING":
+                case "BUILD":
                 case "REBUILD":
                     return CloudInstanceState.BUILDING;
                 case "ACTIVE":


### PR DESCRIPTION
OpenStack is returning `BUILD` instead of `BUILDING` just after the instance creation.