### PR TITLE
Fix the token validity logic

### DIFF
--- a/src/services/openstack/openstack-authenticator.ts
+++ b/src/services/openstack/openstack-authenticator.ts
@@ -38,8 +38,8 @@ export class OpenstackAuthenticator {
      */
     private isTokenExpired(): boolean {
         const now = new Date();
-        const validity = sub(now, {minutes: 30});
-        if (isAfter(validity, this._principal.expiresAt,)) {
+        const validity = sub(this._principal.expiresAt, {minutes: 30});
+        if (isAfter(now, validity)) {
             logger.info('Token has expired');
             this._principal = null;
             return true;


### PR DESCRIPTION
The logic is wrong, it consider the token valid for 30 minutes more.
So the provider fails each time the token reach its end during 1 hour.

This PR fixes that.